### PR TITLE
Add Markdown editor demo with live preview

### DIFF
--- a/demo/markdown.html
+++ b/demo/markdown.html
@@ -1,0 +1,63 @@
+<!doctype html>
+
+<title>CodeMirror: Markdown Editor</title>
+<meta charset="utf-8"/>
+<link rel=stylesheet href="../doc/docs.css">
+
+<link rel=stylesheet href=../lib/codemirror.css>
+<script src=../lib/codemirror.js></script>
+<script src=../mode/markdown/markdown.js></script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<style type=text/css>
+  .CodeMirror {
+    float: left;
+    width: 50%;
+    border: 1px solid black;
+    height: 300px;
+  }
+  #preview {
+    float: left;
+    width: 49%;
+    height: 300px;
+    border: 1px solid black;
+    border-left: 0;
+    overflow: auto;
+    padding: 10px;
+  }
+</style>
+<div id=nav>
+  <a href="http://codemirror.net"><h1>CodeMirror</h1><img id=logo src="../doc/logo.png"></a>
+
+  <ul>
+    <li><a href="../index.html">Home</a>
+    <li><a href="../doc/manual.html">Manual</a>
+    <li><a href="https://github.com/codemirror/codemirror">Code</a>
+  </ul>
+  <ul>
+    <li><a class=active href="#">Markdown editor</a>
+  </ul>
+</div>
+
+<article>
+<h2>Markdown editor</h2>
+
+<textarea id=code name=code># Markdown editor
+
+Type *Markdown* on the left to see it rendered on the right.
+</textarea>
+<div id=preview></div>
+<script>
+  var editor = CodeMirror.fromTextArea(document.getElementById('code'), {
+    mode: 'markdown',
+    lineNumbers: true,
+    lineWrapping: true
+  });
+  editor.on('change', updatePreview);
+
+  function updatePreview() {
+    document.getElementById('preview').innerHTML = marked(editor.getValue());
+  }
+
+  updatePreview();
+</script>
+</article>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
     <option value="demo/tern.html">Tern integration</option>
     <option value="demo/merge.html">Merge/diff interface</option>
     <option value="demo/fullscreen.html">Full-screen editor</option>
+    <option value="demo/markdown.html">Markdown editor</option>
     <option value="demo/simplescrollbars.html">Custom scrollbars</option>
   </select></form>
   <script>


### PR DESCRIPTION
## Summary
- add a Markdown editor demo with live preview
- link Markdown editor demo from homepage demo list

## Testing
- `npm test` *(fails: phantomjs could not load the shared library `libproviders.so`)*

------
https://chatgpt.com/codex/tasks/task_e_689528d3d0ec832fb261f3047a6c3239
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a Markdown editor demo with live preview and linked it from the homepage demo list.

- **New Features**
  - Users can write Markdown and see the rendered output side by side in the demo.

<!-- End of auto-generated description by cubic. -->

